### PR TITLE
feat: Add some interactive components

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,12 @@ concepts directly:
   Estimate how much memory the KV cache consumes.
 - [GPU Execution and Memory Map](/kernel-optimization/gpu-architecture-fundamentals/):
   Visualize how threads, warps, SMs, and the GPU memory hierarchy fit together.
+- [GPU Memory Explorer](/kernel-optimization/gpu-architecture-fundamentals/gpu-memory/):
+  Understand different memory tiers and see how reuse scope changes as data moves.
+- [Streaming Multiprocessor Explorer](/kernel-optimization/gpu-architecture-fundamentals/streaming-multiprocessors/#what-an-sm-contains):
+  Explore the units inside an SM and see how many of each an H100 has.
+- [Warp Scheduler Visualizer](/kernel-optimization/gpu-architecture-fundamentals/streaming-multiprocessors/#how-warp-scheduling-hides-latency):
+  Compare too few, enough, and extra resident warps on a scheduler timeline.
 
 ## Contributing
 

--- a/docs/kernel-optimization/gpu-architecture-fundamentals/gpu-memory.md
+++ b/docs/kernel-optimization/gpu-architecture-fundamentals/gpu-memory.md
@@ -10,7 +10,8 @@ keywords:
     - Shared memory bank conflicts
 ---
 
-import LinkList from '@site/src/components/LinkList';
+import LinkList from '@site/src/components/LinkList'; import
+MemoryHierarchyExplorer from '@site/src/components/MemoryHierarchyExplorer';
 
 # GPU memory hierarchy
 
@@ -20,6 +21,12 @@ provides much more capacity off-chip. Most
 [GPU kernel optimization techniques](/kernel-optimization/kernel-optimization-for-llm-inference/)
 come down to moving less data or reusing data at a faster level of this
 hierarchy.
+
+Each step down the hierarchy buys capacity but moves data farther from compute.
+Select a tier below to see how the physical location changes the group that can
+reuse the same data.
+
+<MemoryHierarchyExplorer />
 
 ## Registers
 

--- a/docs/kernel-optimization/gpu-architecture-fundamentals/streaming-multiprocessors.md
+++ b/docs/kernel-optimization/gpu-architecture-fundamentals/streaming-multiprocessors.md
@@ -9,7 +9,9 @@ keywords:
     - block residency
 ---
 
-import LinkList from '@site/src/components/LinkList';
+import LinkList from '@site/src/components/LinkList'; import
+WarpSchedulerVisualizer from '@site/src/components/WarpSchedulerVisualizer';
+import SMFloorplan from '@site/src/components/SMFloorplan';
 
 # Streaming multiprocessors
 
@@ -29,7 +31,7 @@ The exact design changes between GPU generations, but an SM typically contains:
   units on AMD GPUs) for integer and floating-point arithmetic
 - [Tensor Cores](/kernel-optimization/gpu-architecture-fundamentals/tensor-cores/)
   for accelerated matrix operations (on modern architectures)
-- A warp scheduler that picks ready warps and issues instructions each cycle
+- Warp schedulers that pick ready warps and issue instructions each cycle
 - A register file, shared memory, and L1 cache. On many architectures, shared
   memory and L1 share on-chip resources and can be configured. For more
   information, see the
@@ -39,6 +41,24 @@ The exact design changes between GPU generations, but an SM typically contains:
 On-chip means physically located on the GPU silicon die itself, right next to
 the compute units. Off-chip means outside the GPU chip, which requires traveling
 across memory interfaces (wires, controllers).
+:::
+
+Some resources are partitioned across four processing blocks, while others are
+shared across the SM. In an H100 SM, each processing block has a dedicated
+scheduler, register file, and execution units. All four processing blocks share
+the L1 and shared memory pool.
+
+<SMFloorplan />
+
+:::note
+A **processing block** (also called an
+[SM sub-partition](https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#streaming-multiprocessor))
+is not the same as a
+[thread block](/kernel-optimization/gpu-architecture-fundamentals/threads-warps-blocks/#thread-blocks).
+A processing block is a fixed hardware division of the SM. A thread block is a
+software grouping of threads that you choose at launch. The GPU assigns a thread
+block to one SM, and that block's warps are then distributed across the SM's
+processing blocks.
 :::
 
 A modern data center GPU has many SMs. For example, the NVIDIA H100 SXM has 132
@@ -62,6 +82,12 @@ SM. The GPU uses this pool of ready work to hide latency and sustain throughput.
 More resident warps only help when they provide useful alternatives. If every
 warp waits on the same bottleneck, or if the kernel already saturates a compute
 pipeline, adding more warps may provide little benefit.
+
+Choose a scenario below and read each column from top to bottom. The warp rows
+show whether each warp is issuing, waiting on memory, or ready. The final row
+shows which warp the scheduler selects.
+
+<WarpSchedulerVisualizer />
 
 ## Block residency
 

--- a/docs/model-preparation/llm-quantization.md
+++ b/docs/model-preparation/llm-quantization.md
@@ -91,7 +91,8 @@ not activated parameters per token.
 
 <QuantizationVisualizer />
 
-This calculator estimates **weight memory only**. Use the
+This calculator estimates **weight memory only**. Actual usage can be much
+higher due to KV cache, activations, and framework overhead. Use the
 [GPU memory calculator](/getting-started/calculating-gpu-memory-for-llms/) to
 estimate your overall requirements.
 

--- a/src/components/Calculator/Quantization/index.tsx
+++ b/src/components/Calculator/Quantization/index.tsx
@@ -100,13 +100,6 @@ function QuantizationVisualizer() {
                 onChange={(e) => handleParamsChange(Number(e.target.value))}
               />
             </FormItem>
-            <div className={styles.note}>
-              <div className={styles.label}>Note:</div>
-              <div>
-                Memory shown covers model weights only. Actual usage can be much
-                higher due to KV cache, activations, and framework overhead
-              </div>
-            </div>
           </div>
           <div className={styles.chart}>
             <div className={styles.chartTitle}>Weights memory by format</div>

--- a/src/components/Calculator/Quantization/styles.module.css
+++ b/src/components/Calculator/Quantization/styles.module.css
@@ -85,12 +85,13 @@
 
 .bodyContent {
   display: flex;
-  gap: 2rem;
+  gap: 1.5rem;
   margin-top: 1.5rem;
 }
 
+/* Kept narrow so the bar chart gets the remaining width. */
 .input {
-  flex: 0 0 14rem;
+  flex: 0 0 11rem;
 }
 
 .input .title {
@@ -99,25 +100,6 @@
   line-height: 1.75rem;
   font-weight: 400;
   margin-bottom: 1rem;
-}
-
-.note {
-  border: 1px solid var(--Elements-Twilight-30-60);
-  background: #fffbeb;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  margin-top: 1.5rem;
-  padding: 1rem;
-  border-radius: 4px;
-  color: var(--Elements-Twilight-70-20);
-}
-
-.label {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-  color: var(--Elements-Twilight-100-0);
 }
 
 /* ── Bar chart ── */
@@ -146,7 +128,7 @@
 
 .chartColLabel {
   flex-shrink: 0;
-  width: 7rem;
+  width: 5.5rem;
 }
 
 .chartColBar {
@@ -156,7 +138,7 @@
 
 .chartColValue {
   flex-shrink: 0;
-  width: 5rem;
+  width: 4.5rem;
   font-size: 0.75rem;
   font-weight: 400;
   color: var(--Elements-Twilight-60-50);
@@ -165,7 +147,7 @@
 
 .chartColBadge {
   flex-shrink: 0;
-  width: 6.5rem;
+  width: 5.5rem;
   font-size: 0.75rem;
   font-weight: 400;
   color: var(--Elements-Twilight-60-50);
@@ -181,7 +163,7 @@
 
 .chartLabel {
   flex-shrink: 0;
-  width: 7rem;
+  width: 5.5rem;
   font-size: 0.8125rem;
   font-weight: 400;
   color: var(--Elements-Twilight-70-20);
@@ -205,7 +187,7 @@
 
 .chartValue {
   flex-shrink: 0;
-  width: 5rem;
+  width: 4.5rem;
   font-size: 0.8125rem;
   font-weight: 400;
   color: var(--Elements-Twilight-70-20);
@@ -214,7 +196,7 @@
 
 .badge {
   flex-shrink: 0;
-  width: 6.5rem;
+  width: 5.5rem;
   font-size: 0.6875rem;
   font-weight: 400;
   text-align: center;
@@ -262,9 +244,6 @@
    Preserve the quality-loss scale (none/minimal = green, low = nebula,
    moderate/high = neutral); only swap light fills/text for dark-legible ones. */
 
-:global(html[data-theme='dark']) .note {
-  background: rgba(245, 158, 11, 0.1);
-}
 :global(html[data-theme='dark']) .chartBarTrack {
   background: rgba(255, 255, 255, 0.06);
 }

--- a/src/components/MemoryHierarchyExplorer/index.tsx
+++ b/src/components/MemoryHierarchyExplorer/index.tsx
@@ -1,0 +1,245 @@
+import { type CSSProperties, useState } from 'react'
+import styles from './styles.module.css'
+
+type LevelId = 'registers' | 'shared' | 'l1' | 'l2' | 'hbm'
+
+interface Level {
+  id: LevelId
+  label: string
+  location: string
+  scope: string
+  explanation: string
+  color: string
+  tint: string
+}
+
+const LEVELS: Level[] = [
+  {
+    id: 'registers',
+    label: 'Registers',
+    location: 'Inside an SM',
+    scope: 'One thread',
+    explanation:
+      "Private storage for each thread. Other threads can't directly access another thread's registers and must communicate through shared memory, global memory, or warp shuffles.",
+    color: '#7c3aed',
+    tint: 'rgba(124, 58, 237, 0.14)'
+  },
+  {
+    id: 'shared',
+    label: 'Shared memory',
+    location: 'Inside an SM',
+    scope: 'One block',
+    explanation:
+      'Threads in one block can cooperate on a tile and reuse the same data before the block finishes.',
+    color: '#2563eb',
+    tint: 'rgba(37, 99, 235, 0.13)'
+  },
+  {
+    id: 'l1',
+    label: 'L1 cache',
+    location: 'Inside an SM',
+    scope: 'One SM',
+    explanation:
+      'Hardware can serve a cached line to work running on the same SM without another trip down the hierarchy.',
+    color: '#0891b2',
+    tint: 'rgba(8, 145, 178, 0.13)'
+  },
+  {
+    id: 'l2',
+    label: 'L2 cache',
+    location: 'On the GPU die',
+    scope: 'Every SM',
+    explanation:
+      'One shared cache can capture reuse across blocks and SMs before a request reaches off-chip memory.',
+    color: '#d97706',
+    tint: 'rgba(217, 119, 6, 0.14)'
+  },
+  {
+    id: 'hbm',
+    label: 'HBM',
+    location: 'Off-chip',
+    scope: 'The full GPU',
+    explanation:
+      'Large tensors live here. An L2 miss requires fetching data from off-chip HBM. Tiling and fusion reduce these round-trips.',
+    color: '#ea580c',
+    tint: 'rgba(234, 88, 12, 0.14)'
+  }
+]
+
+const SMS = Array.from({ length: 4 }, (_, index) => index)
+const BLOCKS = Array.from({ length: 2 }, (_, index) => index)
+const THREADS = Array.from({ length: 8 }, (_, index) => index)
+const HBM_BANKS = Array.from({ length: 8 }, (_, index) => index)
+
+export default function MemoryHierarchyExplorer() {
+  const [selected, setSelected] = useState<LevelId>('shared')
+  const level = LEVELS.find((candidate) => candidate.id === selected)!
+  const levelStyle = {
+    '--level-color': level.color,
+    '--level-tint': level.tint
+  } as CSSProperties
+
+  return (
+    <div className={styles.container} style={levelStyle}>
+      <div className={styles.header}>
+        <div>
+          <div className={styles.headerTitle}>GPU Memory Explorer</div>
+          <div className={styles.headerDescription}>
+            Select a memory space to see where data lives and how far reuse can
+            reach.
+          </div>
+        </div>
+        <div className={styles.direction} aria-hidden="true">
+          <span>closer to compute</span>
+          <span className={styles.directionLine} />
+          <span>farther from compute</span>
+        </div>
+      </div>
+
+      <div className={styles.levels} aria-label="Memory space" role="group">
+        {LEVELS.map((candidate, index) => (
+          <button
+            key={candidate.id}
+            type="button"
+            className={`${styles.levelButton} ${candidate.id === selected ? styles.levelButtonActive : ''}`}
+            aria-pressed={candidate.id === selected}
+            onClick={() => setSelected(candidate.id)}
+          >
+            <span className={styles.levelNumber}>{index + 1}</span>
+            {candidate.label}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.diagram}>
+          <div
+            className={`${styles.die} ${selected === 'l2' ? styles.regionActive : ''}`}
+          >
+            <div className={styles.regionHeader}>
+              <span className={styles.regionTag}>On-chip</span>
+              <span>GPU die</span>
+            </div>
+
+            <div className={styles.smGrid}>
+              {SMS.map((sm) => {
+                const activeSM = selected === 'l1' && sm === 0
+
+                return (
+                  <div
+                    key={sm}
+                    className={`${styles.sm} ${activeSM ? styles.regionActive : ''}`}
+                  >
+                    <div className={styles.smHeader}>
+                      <span>SM {sm}</span>
+                      <span
+                        className={`${styles.l1} ${activeSM ? styles.memoryActive : ''}`}
+                      >
+                        L1
+                      </span>
+                    </div>
+
+                    <div className={styles.blockGrid}>
+                      {BLOCKS.map((block) => {
+                        const activeBlock =
+                          selected === 'shared' && sm === 0 && block === 0
+
+                        return (
+                          <div
+                            key={block}
+                            className={`${styles.block} ${activeBlock ? styles.regionActive : ''}`}
+                          >
+                            <div className={styles.blockHeader}>
+                              <span>Block {block}</span>
+                              <span
+                                className={`${styles.smem} ${activeBlock ? styles.memoryActive : ''}`}
+                              >
+                                SMEM
+                              </span>
+                            </div>
+                            <div className={styles.threads}>
+                              {THREADS.map((thread) => {
+                                const activeThread =
+                                  selected === 'registers' &&
+                                  sm === 0 &&
+                                  block === 0 &&
+                                  thread === 0
+
+                                return (
+                                  <span
+                                    key={thread}
+                                    className={`${styles.thread} ${activeThread ? styles.threadActive : ''}`}
+                                    title={
+                                      activeThread
+                                        ? 'Register value held by one thread'
+                                        : undefined
+                                    }
+                                  />
+                                )
+                              })}
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div
+              className={`${styles.l2} ${selected === 'l2' ? styles.memoryActive : ''}`}
+            >
+              <span>L2 cache</span>
+              <span>shared by every SM</span>
+            </div>
+          </div>
+
+          <div className={styles.bus}>
+            <span />
+            <span>memory bus</span>
+            <span />
+          </div>
+
+          <div
+            className={`${styles.hbm} ${selected === 'hbm' ? styles.regionActive : ''}`}
+          >
+            <div className={styles.hbmLabel}>
+              <span className={styles.regionTag}>Off-chip</span>
+              <strong>HBM</strong>
+            </div>
+            <div className={styles.hbmBanks} aria-hidden="true">
+              {HBM_BANKS.map((bank) => (
+                <span
+                  key={bank}
+                  className={selected === 'hbm' ? styles.memoryActive : ''}
+                />
+              ))}
+            </div>
+            <span className={styles.hbmContents}>
+              weights · KV cache · activations
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.readout} aria-live="polite">
+          <div className={styles.location}>{level.location}</div>
+          <div className={styles.readoutMain}>
+            <span className={styles.tile} aria-hidden="true" />
+            <div>
+              <div className={styles.readoutLabel}>Reuse scope</div>
+              <div className={styles.scope}>{level.scope}</div>
+            </div>
+          </div>
+          <p>{level.explanation}</p>
+        </div>
+      </div>
+
+      <div className={styles.takeaway}>
+        <span>Key trade-off</span>
+        Moving data closer to compute makes access faster, but narrows the group
+        that can reuse the same value.
+      </div>
+    </div>
+  )
+}

--- a/src/components/MemoryHierarchyExplorer/index.tsx
+++ b/src/components/MemoryHierarchyExplorer/index.tsx
@@ -82,17 +82,15 @@ export default function MemoryHierarchyExplorer() {
   return (
     <div className={styles.container} style={levelStyle}>
       <div className={styles.header}>
-        <div>
-          <div className={styles.headerTitle}>GPU Memory Explorer</div>
-          <div className={styles.headerDescription}>
-            Select a memory space to see where data lives and how far reuse can
-            reach.
-          </div>
+        <div className={styles.headerTitle}>GPU Memory Explorer</div>
+        <div className={styles.headerDescription}>
+          Select a memory space to see where data lives and how far reuse can
+          reach.
         </div>
         <div className={styles.direction} aria-hidden="true">
-          <span>closer to compute</span>
+          <span>Closer to compute</span>
           <span className={styles.directionLine} />
-          <span>farther from compute</span>
+          <span>Farther from compute</span>
         </div>
       </div>
 

--- a/src/components/MemoryHierarchyExplorer/styles.module.css
+++ b/src/components/MemoryHierarchyExplorer/styles.module.css
@@ -8,10 +8,6 @@
 }
 
 .header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1.5rem;
   padding: 1.25rem 1.5rem;
   background: var(--Elements-Twilight-5-90);
 }
@@ -30,11 +26,14 @@
   line-height: 1.4;
 }
 
+/* Its own full-width row, but capped and centred so the two ends read as a
+   pair instead of drifting to opposite edges. */
 .direction {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  min-width: 16rem;
+  max-width: 400px;
+  margin: 0.9rem auto 0;
   color: var(--Elements-Twilight-60-50);
   font-size: 0.6875rem;
   white-space: nowrap;
@@ -455,14 +454,6 @@
 }
 
 @media (max-width: 800px) {
-  .header {
-    align-items: flex-start;
-  }
-
-  .direction {
-    display: none;
-  }
-
   .body {
     grid-template-columns: 1fr;
   }

--- a/src/components/MemoryHierarchyExplorer/styles.module.css
+++ b/src/components/MemoryHierarchyExplorer/styles.module.css
@@ -1,0 +1,553 @@
+.container {
+  --level-color: #2563eb;
+  --level-tint: rgba(37, 99, 235, 0.13);
+  overflow: hidden;
+  margin: 1.5rem 0;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+}
+
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--Elements-Twilight-5-90);
+}
+
+.headerTitle {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.headerDescription {
+  margin-top: 0.25rem;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.direction {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 16rem;
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
+
+.directionLine {
+  position: relative;
+  flex: 1;
+  height: 1px;
+  background: var(--Elements-Twilight-30-60);
+}
+
+.directionLine::before,
+.directionLine::after {
+  position: absolute;
+  top: -3px;
+  width: 6px;
+  height: 6px;
+  border-top: 1px solid var(--Elements-Twilight-30-60);
+  border-right: 1px solid var(--Elements-Twilight-30-60);
+  content: '';
+}
+
+.directionLine::before {
+  left: 0;
+  transform: rotate(-135deg);
+}
+
+.directionLine::after {
+  right: 0;
+  transform: rotate(45deg);
+}
+
+.levels {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border-top: 1px solid var(--Elements-Twilight-20-70);
+  border-bottom: 1px solid var(--Elements-Twilight-20-70);
+  background: var(--Elements-Twilight-1-90);
+}
+
+.levelButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.35rem;
+  border: 0;
+  border-right: 1px solid var(--Elements-Twilight-20-70);
+  background: transparent;
+  color: var(--Elements-Twilight-70-20);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.75rem;
+  transition:
+    background 150ms ease,
+    color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.levelButton:last-child {
+  border-right: 0;
+}
+
+.levelButton:hover {
+  background: var(--Elements-Twilight-5-90);
+  color: var(--Elements-Twilight-100-0);
+}
+
+.levelButton:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--level-color);
+  outline-offset: -2px;
+}
+
+.levelButtonActive {
+  background: var(--level-tint);
+  color: var(--level-color);
+  box-shadow: inset 0 -3px 0 var(--level-color);
+  font-weight: 500;
+}
+
+.levelNumber {
+  display: grid;
+  width: 1.1rem;
+  height: 1.1rem;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-size: 0.6875rem;
+  line-height: 1;
+  opacity: 0.75;
+}
+
+.body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 12rem;
+  gap: 1rem;
+  align-items: stretch;
+  padding: 1.25rem 1.5rem;
+}
+
+.diagram {
+  min-width: 0;
+}
+
+.die,
+.sm,
+.block,
+.hbm {
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.die {
+  padding: 0.55rem;
+  border: 1px dashed var(--Elements-Twilight-40-60);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-1-90);
+}
+
+.regionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-bottom: 0.55rem;
+  color: var(--Elements-Twilight-60-40);
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.regionTag {
+  display: inline-flex;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  background: var(--Elements-Twilight-10-90);
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.smGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.sm {
+  min-width: 0;
+  padding: 0.32rem;
+  border: 1px solid #a78bfa;
+  border-radius: 3px;
+  background: rgba(139, 92, 246, 0.06);
+}
+
+.smHeader,
+.blockHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+}
+
+.smHeader {
+  margin-bottom: 0.35rem;
+  color: #6d28d9;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.6875rem;
+}
+
+.l1,
+.smem {
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  font-family: inherit;
+  line-height: 1.2;
+}
+
+.l1 {
+  padding: 0.08rem 0.2rem;
+  color: #0891b2;
+  font-size: 0.625rem;
+}
+
+.blockGrid {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.block {
+  min-width: 0;
+  padding: 0.28rem;
+  border: 1px solid #93c5fd;
+  border-radius: 3px;
+  background: rgba(37, 99, 235, 0.04);
+}
+
+/* Wraps rather than overflowing once the SM column gets narrow. */
+.blockHeader {
+  flex-wrap: wrap;
+  row-gap: 0.12rem;
+  margin-bottom: 0.25rem;
+  color: #2563eb;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.625rem;
+}
+
+.smem {
+  padding: 0.06rem 0.16rem;
+  font-size: 0.625rem;
+}
+
+.threads {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.18rem;
+}
+
+.thread {
+  display: block;
+  min-width: 0;
+  height: 0.375rem;
+  border: 1px solid #c4b5fd;
+  border-radius: 1px;
+  background: var(--Elements-Twilight-0-100);
+}
+
+.threadActive {
+  border-color: var(--level-color);
+  background: var(--level-color);
+  box-shadow: 0 0 0 2px var(--level-tint);
+}
+
+.l2 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid #fbbf24;
+  border-radius: 3px;
+  background: rgba(251, 191, 36, 0.08);
+  color: #a16207;
+  font-size: 0.6875rem;
+}
+
+.l2 span:last-child {
+  font-size: 0.625rem;
+  opacity: 0.8;
+}
+
+.bus {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.4rem;
+  align-items: center;
+  padding: 0.35rem 0;
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.625rem;
+  text-transform: uppercase;
+}
+
+.bus span:first-child,
+.bus span:last-child {
+  height: 1px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--Elements-Twilight-30-60) 0,
+    var(--Elements-Twilight-30-60) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+}
+
+.hbm {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #fb923c;
+  border-radius: 4px;
+  background: rgba(251, 146, 60, 0.07);
+}
+
+.hbmLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #c2410c;
+  font-size: 0.75rem;
+}
+
+.hbmBanks {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.18rem;
+}
+
+.hbmBanks span {
+  display: block;
+  height: 1rem;
+  border: 1px solid #fdba74;
+  border-radius: 2px;
+  background: rgba(251, 146, 60, 0.12);
+}
+
+.hbmContents {
+  color: #9a3412;
+  font-size: 0.625rem;
+  white-space: nowrap;
+}
+
+.regionActive {
+  border-color: var(--level-color);
+  background: var(--level-tint);
+  box-shadow: inset 0 0 0 1px var(--level-color);
+}
+
+.memoryActive {
+  border-color: var(--level-color) !important;
+  background: var(--level-color) !important;
+  color: white !important;
+}
+
+.readout {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+  background: linear-gradient(145deg, var(--level-tint), transparent 70%);
+}
+
+.location {
+  color: var(--level-color);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.readoutMain {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--Elements-Twilight-20-70);
+}
+
+.tile {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  border: 1px solid var(--level-color);
+  border-radius: 4px;
+  background:
+    linear-gradient(
+      90deg,
+      transparent 47%,
+      var(--level-color) 48%,
+      var(--level-color) 52%,
+      transparent 53%
+    ),
+    linear-gradient(
+      transparent 47%,
+      var(--level-color) 48%,
+      var(--level-color) 52%,
+      transparent 53%
+    ),
+    var(--level-tint);
+}
+
+.readoutLabel {
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+}
+
+.scope {
+  margin-top: 0.1rem;
+  color: var(--Elements-Twilight-100-0);
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.readout p {
+  margin: 0.75rem 0 0;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.takeaway {
+  display: flex;
+  gap: 0.55rem;
+  padding: 0.7rem 1.5rem;
+  border-top: 1px solid var(--Elements-Twilight-20-70);
+  background: var(--Elements-Twilight-1-90);
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.takeaway span {
+  flex: 0 0 auto;
+  color: var(--Elements-Twilight-100-0);
+  font-weight: 500;
+}
+
+@media (max-width: 800px) {
+  .header {
+    align-items: flex-start;
+  }
+
+  .direction {
+    display: none;
+  }
+
+  .body {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .header,
+  .body {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+
+  .levels {
+    display: flex;
+    overflow-x: auto;
+  }
+
+  .levelButton {
+    min-width: 7.25rem;
+    flex: 1 0 auto;
+  }
+
+  .smGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .hbm {
+    grid-template-columns: auto 1fr;
+  }
+
+  .hbmContents {
+    display: none;
+  }
+
+  .takeaway {
+    display: block;
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+
+  .takeaway span {
+    display: block;
+    margin-bottom: 0.2rem;
+  }
+}
+
+:global(html[data-theme='dark']) .sm {
+  background: rgba(139, 92, 246, 0.08);
+}
+
+:global(html[data-theme='dark']) .smHeader {
+  color: #c4b5fd;
+}
+
+:global(html[data-theme='dark']) .block {
+  background: rgba(37, 99, 235, 0.06);
+}
+
+:global(html[data-theme='dark']) .blockHeader {
+  color: #93c5fd;
+}
+
+:global(html[data-theme='dark']) .thread {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Cyan-600 is too dark to read against the dark surface. */
+:global(html[data-theme='dark']) .l1 {
+  color: #67e8f9;
+}
+
+:global(html[data-theme='dark']) .l2 {
+  background: rgba(251, 191, 36, 0.08);
+  color: #fcd34d;
+}
+
+:global(html[data-theme='dark']) .hbm {
+  background: rgba(251, 146, 60, 0.08);
+}
+
+:global(html[data-theme='dark']) .hbmLabel,
+:global(html[data-theme='dark']) .hbmContents {
+  color: #fdba74;
+}
+
+:global(html[data-theme='dark']) .regionActive {
+  background: var(--level-tint);
+}

--- a/src/components/SMFloorplan/index.tsx
+++ b/src/components/SMFloorplan/index.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react'
+import styles from './styles.module.css'
+
+type RegionId = 'scheduler' | 'registers' | 'cuda' | 'tensor' | 'smem' | 'tma'
+
+interface Region {
+  id: RegionId
+  name: string
+  count: string
+  role: string
+}
+
+// Figures describe an H100 (Hopper) SM.
+const REGIONS: Record<RegionId, Region> = {
+  scheduler: {
+    id: 'scheduler',
+    name: 'Warp scheduler',
+    count: '4 per SM, one per processing block',
+    role: 'Picks a ready warp each cycle and issues one instruction to it. Four schedulers let one SM issue up to four warp instructions per cycle.'
+  },
+  registers: {
+    id: 'registers',
+    name: 'Register file',
+    count: '256 KB per SM, 64 KB per processing block',
+    role: "Holds each thread's private working values. Register use per thread is often what caps how many warps stay resident."
+  },
+  cuda: {
+    id: 'cuda',
+    name: 'CUDA cores',
+    count: '128 FP32 and 64 INT32 lanes per SM',
+    role: 'General-purpose arithmetic. Elementwise work such as activations, normalization, and sampling runs here.'
+  },
+  tensor: {
+    id: 'tensor',
+    name: 'Tensor Core',
+    count: '4 per SM, fourth generation on H100',
+    role: 'A specialized execution unit. Dense matrix multiplications in prefill and projection layers typically use Tensor Cores.'
+  },
+  smem: {
+    id: 'smem',
+    name: 'L1 cache / shared memory',
+    count: '256 KB per SM, shared by all four blocks',
+    role: 'One SRAM pool split between hardware-managed L1 and programmer-managed shared memory.'
+  },
+  tma: {
+    id: 'tma',
+    name: 'Tensor Memory Accelerator',
+    count: 'Introduced in Hopper',
+    role: 'Copies tiles between HBM and shared memory in the background, so threads spend neither registers nor instructions on address arithmetic.'
+  }
+}
+
+const BLOCKS = [0, 1, 2, 3]
+
+export default function SMFloorplan() {
+  const [selected, setSelected] = useState<RegionId>('tensor')
+  const region = REGIONS[selected]
+
+  function regionClass(id: RegionId) {
+    return `${styles.region} ${id === selected ? styles.regionActive : ''}`
+  }
+
+  function regionProps(id: RegionId) {
+    return {
+      type: 'button' as const,
+      className: regionClass(id),
+      'aria-pressed': id === selected,
+      onClick: () => setSelected(id)
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.headerTitle}>
+          Streaming Multiprocessor Explorer
+        </div>
+        <div className={styles.headerDescription}>
+          Select a unit to see how many an H100 SM has and what it does during
+          inference. Every copy of that unit highlights at once
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.floorplan}>
+          <div className={styles.smLabel}>One SM</div>
+
+          <div className={styles.blocks}>
+            {BLOCKS.map((block) => (
+              <div className={styles.block} key={block}>
+                <div className={styles.blockLabel}>
+                  Processing block {block}
+                </div>
+
+                <button {...regionProps('scheduler')}>Warp scheduler</button>
+                <button {...regionProps('registers')}>
+                  Register file <span className={styles.sub}>64 KB</span>
+                </button>
+
+                <div className={styles.lanes}>
+                  <button {...regionProps('cuda')}>
+                    CUDA cores <span className={styles.sub}>32 FP32</span>
+                  </button>
+                  <button {...regionProps('tensor')}>Tensor Core</button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <button {...regionProps('smem')}>
+            L1 cache / shared memory <span className={styles.sub}>256 KB</span>
+          </button>
+          <button {...regionProps('tma')}>Tensor Memory Accelerator</button>
+        </div>
+
+        <div className={styles.readout} aria-live="polite">
+          <div className={styles.readoutName}>{region.name}</div>
+          <div className={styles.readoutCount}>{region.count}</div>
+          <p className={styles.readoutRole}>{region.role}</p>
+        </div>
+      </div>
+
+      <div className={styles.note}>
+        This is a simplified floorplan. An SM also contains load/store units, special
+        function units, texture units, and instruction caches, and the exact mix
+        changes with every GPU generation.
+      </div>
+    </div>
+  )
+}

--- a/src/components/SMFloorplan/index.tsx
+++ b/src/components/SMFloorplan/index.tsx
@@ -83,7 +83,7 @@ export default function SMFloorplan() {
 
       <div className={styles.body}>
         <div className={styles.floorplan}>
-          <div className={styles.smLabel}>One SM</div>
+          <div className={styles.smLabel}>One NVIDIA H100 SM</div>
 
           <div className={styles.blocks}>
             {BLOCKS.map((block) => (
@@ -121,9 +121,9 @@ export default function SMFloorplan() {
       </div>
 
       <div className={styles.note}>
-        This is a simplified floorplan. An SM also contains load/store units, special
-        function units, texture units, and instruction caches, and the exact mix
-        changes with every GPU generation.
+        This is a simplified floorplan. An SM also contains load/store units,
+        special function units, texture units, and instruction caches, and the
+        exact mix changes with every GPU generation.
       </div>
     </div>
   )

--- a/src/components/SMFloorplan/styles.module.css
+++ b/src/components/SMFloorplan/styles.module.css
@@ -1,0 +1,203 @@
+.container {
+  overflow: hidden;
+  margin: 1.5rem 0;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+}
+
+.header {
+  padding: 1.25rem 1.5rem;
+  background: var(--Elements-Twilight-5-90);
+}
+
+.headerTitle {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.headerDescription {
+  margin-top: 0.25rem;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 12rem;
+  gap: 1rem;
+  align-items: start;
+  padding: 1.25rem 1.5rem;
+}
+
+/* ── Floorplan ── */
+
+.floorplan {
+  min-width: 0;
+  padding: 0.6rem;
+  border: 1px dashed var(--Elements-Twilight-40-60);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-1-90);
+}
+
+.smLabel {
+  margin-bottom: 0.5rem;
+  color: var(--Elements-Twilight-60-40);
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.blocks {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.block {
+  min-width: 0;
+  padding: 0.35rem;
+  border: 1px solid var(--Elements-Twilight-30-60);
+  border-radius: 3px;
+}
+
+.blockLabel {
+  margin-bottom: 0.3rem;
+  color: var(--Elements-Twilight-60-50);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.625rem;
+}
+
+.lanes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.25rem;
+}
+
+/* ── Clickable units ── */
+
+.region {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 0.25rem;
+  padding: 0.3rem 0.35rem;
+  overflow: hidden;
+  border: 1px solid var(--Elements-Twilight-30-60);
+  border-radius: 3px;
+  background: var(--Elements-Twilight-0-100);
+  color: var(--Elements-Twilight-70-20);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.6875rem;
+  line-height: 1.25;
+  text-align: left;
+  text-overflow: ellipsis;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.lanes .region {
+  margin-bottom: 0;
+}
+
+.region:hover:not(.regionActive) {
+  border-color: var(--Elements-Neb-Ultra);
+}
+
+.region:focus-visible {
+  outline: 2px solid var(--Elements-Neb-Ultra);
+  outline-offset: 1px;
+}
+
+.regionActive {
+  border-color: var(--Elements-Neb-Ultra);
+  background: var(--Elements-Neb-Ultra);
+  color: var(--Elements-Twilight-0-100);
+}
+
+.sub {
+  color: var(--Elements-Twilight-60-50);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.625rem;
+}
+
+.regionActive .sub {
+  color: inherit;
+  opacity: 0.85;
+}
+
+/* The two shared units sit below the blocks, spanning the whole SM. */
+.floorplan > .region {
+  margin-top: 0.4rem;
+  margin-bottom: 0;
+}
+
+/* ── Readout ── */
+
+.readout {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-1-90);
+}
+
+.readoutName {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.readoutCount {
+  margin-top: 0.2rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--Elements-Twilight-20-70);
+  color: var(--Elements-Neb-Ultra);
+  font-size: 0.75rem;
+}
+
+.readoutRole {
+  margin: 0.6rem 0 0;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.note {
+  padding: 0.7rem 1.5rem;
+  border-top: 1px solid var(--Elements-Twilight-20-70);
+  background: var(--Elements-Twilight-1-90);
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 800px) {
+  .body {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .header,
+  .body,
+  .note {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+
+  .blocks {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Dark mode ── */
+
+:global(html[data-theme='dark']) .region:hover:not(.regionActive) {
+  background: rgba(255, 255, 255, 0.04);
+}

--- a/src/components/SMFloorplan/styles.module.css
+++ b/src/components/SMFloorplan/styles.module.css
@@ -139,8 +139,10 @@
 
 /* ── Readout ── */
 
+/* Type scale mirrors the readout in MemoryHierarchyExplorer so the two
+   GPU architecture components read as one system. */
 .readout {
-  padding: 0.85rem 1rem;
+  padding: 1rem;
   border: 1px solid var(--Elements-Twilight-20-70);
   border-radius: 4px;
   background: var(--Elements-Twilight-1-90);
@@ -148,9 +150,9 @@
 
 .readoutName {
   color: var(--Elements-Twilight-100-0);
-  font-size: 0.9375rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  line-height: 1.3;
+  line-height: 1.25;
 }
 
 .readoutCount {
@@ -158,14 +160,14 @@
   padding-bottom: 0.6rem;
   border-bottom: 1px solid var(--Elements-Twilight-20-70);
   color: var(--Elements-Neb-Ultra);
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
 }
 
 .readoutRole {
   margin: 0.6rem 0 0;
   color: var(--Elements-Twilight-70-20);
-  font-size: 0.8125rem;
-  line-height: 1.45;
+  font-size: 0.75rem;
+  line-height: 1.5;
 }
 
 .note {

--- a/src/components/WarpSchedulerVisualizer/index.tsx
+++ b/src/components/WarpSchedulerVisualizer/index.tsx
@@ -59,9 +59,11 @@ export default function WarpSchedulerVisualizer() {
       <div className={styles.header}>
         <div className={styles.headerTitle}>Warp Scheduler Visualizer</div>
         <div className={styles.headerDescription}>
-          Learn how warp scheduling hides memory latency. One scheduler chooses
-          one ready warp per cycle. More resident warps give the scheduler more
-          work to choose from.
+          A scheduler issues at most one instruction per cycle, and can only
+          pick a warp that is ready. A warp that reads memory isn&rsquo;t ready
+          again until its data arrives &mdash; tens of cycles on an L1 hit,
+          hundreds on an HBM miss, fixed at {MEMORY_WAIT} here. More resident
+          warps give the scheduler something to run in those gaps.
         </div>
       </div>
 
@@ -100,6 +102,16 @@ export default function WarpSchedulerVisualizer() {
           <span className={styles.ruleArrow}>→</span>
           <span className={`${styles.ruleStep} ${styles.ruleReady}`}>
             ready again
+          </span>
+        </div>
+
+        <div className={styles.rule}>
+          <span className={styles.ruleLabel}>Each scheduler picks</span>
+          <span>
+            <strong>at most one warp per cycle</strong>, so a warp that turns
+            ready while the scheduler is busy has to wait its turn. A warp
+            picked the moment it turns ready shows Issue, so Ready only marks a
+            cycle spent waiting for a free slot.
           </span>
         </div>
 
@@ -183,11 +195,11 @@ export default function WarpSchedulerVisualizer() {
         </div>
 
         <div className={styles.note}>
-          Simplified model: the timeline starts with every resident warp ready.
-          Real memory waits can last hundreds of cycles, and instruction
-          dependencies create other stalls. This timeline also doesn't mean an
-          SM issues only one warp instruction per cycle: the one-per-cycle limit
-          belongs to a single scheduler, and an SM has several.
+          This is a simplified model: the timeline starts with every resident warp
+          ready, every warp waits the same number of cycles, and real kernels stall
+          on instruction dependencies too, not memory alone. The
+          one-instruction-per-cycle limit belongs to a single scheduler, not to
+          the whole SM. An H100 SM has four, each with its own issue slot.
         </div>
       </div>
     </div>

--- a/src/components/WarpSchedulerVisualizer/index.tsx
+++ b/src/components/WarpSchedulerVisualizer/index.tsx
@@ -1,0 +1,195 @@
+import { type CSSProperties, useState } from 'react'
+import styles from './styles.module.css'
+
+const MEMORY_WAIT = 5
+const WARP_PERIOD = MEMORY_WAIT + 1
+const CYCLES = 12
+
+const SCENARIOS = [
+  { warps: 2, label: 'Too few', detail: '2 warps' },
+  { warps: 6, label: 'Enough', detail: '6 warps' },
+  { warps: 9, label: 'Extra', detail: '9 warps' }
+]
+
+type CellState = 'issuing' | 'memory' | 'ready'
+
+function stateLabel(state: CellState) {
+  if (state === 'issuing') return 'Issue'
+  if (state === 'ready') return 'Ready'
+  return ''
+}
+
+export default function WarpSchedulerVisualizer() {
+  const [warps, setWarps] = useState(2)
+  const period = Math.max(WARP_PERIOD, warps)
+  const utilization = Math.min(warps, WARP_PERIOD) / WARP_PERIOD
+
+  function cellState(warp: number, cycle: number): CellState {
+    if (cycle < warp) return 'ready'
+
+    const sinceIssue = (cycle - warp) % period
+    if (sinceIssue === 0) return 'issuing'
+    if (sinceIssue <= MEMORY_WAIT) return 'memory'
+    return 'ready'
+  }
+
+  function issueOwner(cycle: number): number | null {
+    const slot = cycle % period
+    return slot < warps ? slot : null
+  }
+
+  const summary =
+    warps < WARP_PERIOD
+      ? {
+          title: 'Idle gaps remain',
+          text: `Only ${warps} of every ${WARP_PERIOD} issue slots are used. Once each warp has issued, the scheduler has no ready work left.`
+        }
+      : warps === WARP_PERIOD
+        ? {
+            title: 'Memory latency is covered',
+            text: 'When one warp starts waiting, another warp is ready. Every issue slot stays busy.'
+          }
+        : {
+            title: 'A ready queue forms',
+            text: `${WARP_PERIOD} warps already fill every issue slot. The extra ${warps - WARP_PERIOD} become ready before the scheduler can choose them.`
+          }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.headerTitle}>Warp Scheduler Visualizer</div>
+        <div className={styles.headerDescription}>
+          Learn how warp scheduling hides memory latency. One scheduler chooses
+          one ready warp per cycle. More resident warps give the scheduler more
+          work to choose from.
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        <div>
+          <div className={styles.sectionLabel}>Choose a scenario</div>
+          <div
+            className={styles.scenarios}
+            role="group"
+            aria-label="Resident warp scenario"
+          >
+            {SCENARIOS.map((scenario) => (
+              <button
+                key={scenario.warps}
+                type="button"
+                className={`${styles.scenario} ${warps === scenario.warps ? styles.scenarioActive : ''}`}
+                aria-pressed={warps === scenario.warps}
+                onClick={() => setWarps(scenario.warps)}
+              >
+                <span className={styles.scenarioLabel}>{scenario.label}</span>
+                <span className={styles.scenarioDetail}>{scenario.detail}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.rule}>
+          <span className={styles.ruleLabel}>Each warp repeats</span>
+          <span className={`${styles.ruleStep} ${styles.ruleIssue}`}>
+            <strong>1 cycle</strong> issue
+          </span>
+          <span className={styles.ruleArrow}>→</span>
+          <span className={`${styles.ruleStep} ${styles.ruleMemory}`}>
+            <strong>{MEMORY_WAIT} cycles</strong> memory wait
+          </span>
+          <span className={styles.ruleArrow}>→</span>
+          <span className={`${styles.ruleStep} ${styles.ruleReady}`}>
+            ready again
+          </span>
+        </div>
+
+        <div
+          className={styles.timeline}
+          aria-label={`Schedule for ${warps} resident warps`}
+        >
+          <div
+            className={styles.timelineInner}
+            style={{ '--cycles': CYCLES } as CSSProperties}
+          >
+            <div className={styles.cycleRow}>
+              <span className={styles.axisLabel}>Cycle</span>
+              <div className={styles.cycleCells}>
+                {Array.from({ length: CYCLES }, (_, cycle) => (
+                  <span key={cycle}>{cycle + 1}</span>
+                ))}
+              </div>
+            </div>
+
+            {Array.from({ length: warps }, (_, warp) => (
+              <div className={styles.row} key={warp}>
+                <span className={styles.rowLabel}>Warp {warp + 1}</span>
+                <div className={styles.cells}>
+                  {Array.from({ length: CYCLES }, (_, cycle) => {
+                    const state = cellState(warp, cycle)
+                    const label = stateLabel(state)
+
+                    return (
+                      <span
+                        key={cycle}
+                        className={`${styles.cell} ${styles[state]}`}
+                        aria-label={`Warp ${warp + 1}, cycle ${cycle + 1}: ${state === 'memory' ? 'waiting on memory' : label.toLowerCase()}`}
+                        title={
+                          state === 'memory'
+                            ? `Warp ${warp + 1} waits on memory`
+                            : state === 'issuing'
+                              ? `Warp ${warp + 1} issues an instruction`
+                              : `Warp ${warp + 1} is ready`
+                        }
+                      >
+                        {label}
+                      </span>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+
+            <div className={`${styles.row} ${styles.schedulerRow}`}>
+              <span className={styles.rowLabel}>Scheduler</span>
+              <div className={styles.cells}>
+                {Array.from({ length: CYCLES }, (_, cycle) => {
+                  const owner = issueOwner(cycle)
+
+                  return (
+                    <span
+                      key={cycle}
+                      className={`${styles.slot} ${owner === null ? styles.slotIdle : styles.slotUsed}`}
+                    >
+                      {owner === null ? 'Idle' : `W${owner + 1}`}
+                    </span>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.readout}>
+          <div className={styles.metric}>
+            <span className={styles.metricValue}>
+              {Math.round(utilization * 100)}%
+            </span>
+            <span className={styles.metricLabel}>scheduler busy</span>
+          </div>
+          <div>
+            <div className={styles.summaryTitle}>{summary.title}</div>
+            <p className={styles.summaryText}>{summary.text}</p>
+          </div>
+        </div>
+
+        <div className={styles.note}>
+          Simplified model: the timeline starts with every resident warp ready.
+          Real memory waits can last hundreds of cycles, and instruction
+          dependencies create other stalls. This timeline also doesn't mean an
+          SM issues only one warp instruction per cycle: the one-per-cycle limit
+          belongs to a single scheduler, and an SM has several.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/WarpSchedulerVisualizer/styles.module.css
+++ b/src/components/WarpSchedulerVisualizer/styles.module.css
@@ -107,7 +107,13 @@
   font-size: 0.6875rem;
 }
 
+.rule + .rule {
+  margin-top: 0.35rem;
+  align-items: flex-start;
+}
+
 .ruleLabel {
+  flex-shrink: 0;
   margin-right: 0.1rem;
   color: var(--Elements-Twilight-70-20);
   font-weight: 500;

--- a/src/components/WarpSchedulerVisualizer/styles.module.css
+++ b/src/components/WarpSchedulerVisualizer/styles.module.css
@@ -1,0 +1,381 @@
+.container {
+  overflow: hidden;
+  margin: 1.5rem 0;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+}
+
+.header {
+  padding: 1.25rem 1.5rem;
+  background: var(--Elements-Twilight-5-90);
+}
+
+.headerTitle {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 1.2rem;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.headerDescription {
+  margin-top: 0.25rem;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.body {
+  padding: 1.25rem 1.5rem;
+}
+
+.sectionLabel {
+  margin-bottom: 0.45rem;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.scenarios {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.scenario {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-0-100);
+  color: var(--Elements-Twilight-70-20);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease,
+    color 150ms ease;
+}
+
+.scenario:hover {
+  border-color: var(--Elements-Neb-Ultra);
+}
+
+.scenario:focus-visible {
+  outline: 2px solid var(--Elements-Neb-Ultra);
+  outline-offset: 2px;
+}
+
+.scenarioActive {
+  border-color: var(--Elements-Neb-Ultra);
+  background: var(--Elements-Neb-20-Alpha);
+  color: var(--Elements-Neb-Ultra);
+}
+
+.scenarioLabel {
+  overflow: hidden;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scenarioDetail {
+  flex-shrink: 0;
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+}
+
+.scenarioActive .scenarioDetail {
+  color: inherit;
+}
+
+.rule {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.9rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-1-90);
+  color: var(--Elements-Twilight-60-40);
+  font-size: 0.6875rem;
+}
+
+.ruleLabel {
+  margin-right: 0.1rem;
+  color: var(--Elements-Twilight-70-20);
+  font-weight: 500;
+}
+
+.ruleStep {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.ruleStep strong {
+  font-weight: 600;
+}
+
+.ruleIssue {
+  border-color: var(--Elements-Neb-Ultra);
+  background: var(--Elements-Neb-Ultra);
+  color: var(--Elements-Twilight-0-100);
+}
+
+.ruleMemory {
+  border-color: var(--Elements-Twilight-30-60);
+  background: repeating-linear-gradient(
+    135deg,
+    var(--Elements-Twilight-5-90) 0,
+    var(--Elements-Twilight-5-90) 4px,
+    var(--Elements-Twilight-10-90) 4px,
+    var(--Elements-Twilight-10-90) 8px
+  );
+  color: var(--Elements-Twilight-70-20);
+}
+
+.ruleReady {
+  border-color: #f59e0b;
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.ruleArrow {
+  color: var(--Elements-Twilight-60-50);
+}
+
+.timeline {
+  margin-top: 0.9rem;
+  overflow-x: auto;
+  padding-bottom: 0.35rem;
+  scrollbar-color: var(--Elements-Twilight-30-60) transparent;
+  scrollbar-width: thin;
+}
+
+/* Cycle count comes from the component, so the grid can't drift from CYCLES. */
+.timelineInner {
+  min-width: calc(5.25rem + var(--cycles, 12) * 45px);
+}
+
+.cycleRow,
+.row {
+  display: grid;
+  grid-template-columns: 4.75rem minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.cycleRow {
+  margin-bottom: 0.25rem;
+}
+
+.axisLabel,
+.rowLabel {
+  color: var(--Elements-Twilight-60-50);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.6875rem;
+}
+
+.axisLabel {
+  text-transform: uppercase;
+}
+
+.cycleCells,
+.cells {
+  display: grid;
+  grid-template-columns: repeat(var(--cycles, 12), minmax(0, 1fr));
+  gap: 2px;
+}
+
+.cycleCells span {
+  color: var(--Elements-Twilight-60-50);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.625rem;
+  text-align: center;
+}
+
+.row {
+  margin-bottom: 0.2rem;
+}
+
+.cell,
+.slot {
+  display: grid;
+  min-width: 0;
+  min-height: 1.55rem;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.625rem;
+  line-height: 1;
+  transition:
+    border-color 150ms ease,
+    background 150ms ease;
+}
+
+.issuing {
+  border-color: var(--Elements-Neb-Ultra);
+  background: var(--Elements-Neb-Ultra);
+  color: var(--Elements-Twilight-0-100);
+}
+
+.memory {
+  border-color: var(--Elements-Twilight-20-70);
+  background: repeating-linear-gradient(
+    135deg,
+    var(--Elements-Twilight-1-90) 0,
+    var(--Elements-Twilight-1-90) 4px,
+    var(--Elements-Twilight-5-90) 4px,
+    var(--Elements-Twilight-5-90) 8px
+  );
+}
+
+.ready {
+  border-color: #f59e0b;
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.schedulerRow {
+  margin-top: 0.55rem;
+  margin-bottom: 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--Elements-Twilight-20-70);
+}
+
+.schedulerRow .rowLabel {
+  color: var(--Elements-Twilight-100-0);
+  font-weight: 600;
+}
+
+.slot {
+  min-height: 1.75rem;
+  font-weight: 600;
+}
+
+.slotUsed {
+  border-color: var(--Elements-Neb-Ultra);
+  background: var(--Elements-Neb-20-Alpha);
+  color: var(--Elements-Neb-Ultra);
+}
+
+.slotIdle {
+  border-color: var(--Elements-Twilight-30-60);
+  border-style: dashed;
+  background: var(--Elements-Twilight-0-100);
+  color: var(--Elements-Twilight-60-50);
+}
+
+.readout {
+  display: grid;
+  grid-template-columns: 7.25rem 1fr;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--Elements-Twilight-20-70);
+  border-radius: 4px;
+  background: var(--Elements-Twilight-1-90);
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  padding-right: 1rem;
+  border-right: 1px solid var(--Elements-Twilight-20-70);
+}
+
+.metricValue {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 1.75rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.05;
+}
+
+.metricLabel {
+  margin-top: 0.15rem;
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+}
+
+.summaryTitle {
+  color: var(--Elements-Twilight-100-0);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.summaryText {
+  margin: 0.2rem 0 0;
+  color: var(--Elements-Twilight-70-20);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.note {
+  margin-top: 0.75rem;
+  color: var(--Elements-Twilight-60-50);
+  font-size: 0.6875rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .header,
+  .body {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+
+  .scenarios {
+    grid-template-columns: 1fr;
+  }
+
+  .rule {
+    flex-wrap: wrap;
+  }
+
+  .ruleLabel {
+    width: 100%;
+  }
+
+  .readout {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+
+  .metric {
+    padding-right: 0;
+    padding-bottom: 0.65rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--Elements-Twilight-20-70);
+  }
+}
+
+:global(html[data-theme='dark']) .ruleReady,
+:global(html[data-theme='dark']) .ready {
+  background: rgba(245, 158, 11, 0.15);
+  color: #fcd34d;
+}
+
+:global(html[data-theme='dark']) .memory,
+:global(html[data-theme='dark']) .ruleMemory {
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.02) 0,
+    rgba(255, 255, 255, 0.02) 4px,
+    rgba(255, 255, 255, 0.06) 4px,
+    rgba(255, 255, 255, 0.06) 8px
+  );
+}


### PR DESCRIPTION
Added three new interactive components and updated an existing one. The PR preview feature doesn't work, so I put some screenshots here. These are part of the plan to add more visuals, especially for the GPU architecture section. More will come in separate PRs.
 
New:
     
<img width="689" height="593" alt="image" src="https://github.com/user-attachments/assets/1c54a3a3-df28-4f89-81b5-a459f1bc194f" />
 
<img width="699" height="611" alt="image" src="https://github.com/user-attachments/assets/6b41ff49-08ef-4706-9d57-10758b6857dc" />

<img width="689" height="728" alt="image" src="https://github.com/user-attachments/assets/50ac4bc8-48d5-4d08-a196-bec0f9366f72" />

Existing (fixed the layout)

<img width="697" height="541" alt="image" src="https://github.com/user-attachments/assets/6c1726b0-e528-4866-a675-eca36c7cb459" />
