### PR TITLE
[gtm] Add custom event to track header link clicks

### DIFF
--- a/src/components/MarketingHeader/MarketingHeaderHost.tsx
+++ b/src/components/MarketingHeader/MarketingHeaderHost.tsx
@@ -78,9 +78,9 @@ export default function MarketingHeaderHost(): JSX.Element {
     if (!shadowRoot) return;
 
     const onClick: EventListener = (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      const anchor = target.closest('a');
+      const first = event.composedPath()[0];
+      const target = first instanceof Element ? first : null;
+      const anchor = target?.closest('a');
       if (anchor instanceof HTMLAnchorElement) {
         trackHeaderLinkClick(anchor);
       }

--- a/src/components/MarketingHeader/MarketingHeaderHost.tsx
+++ b/src/components/MarketingHeader/MarketingHeaderHost.tsx
@@ -4,6 +4,7 @@ import { useNavbarSecondaryMenu } from '@docusaurus/theme-common/internal';
 import type { PropSidebar } from '@docusaurus/plugin-content-docs';
 import MarketingHeader from './MarketingHeader';
 import headerStyles from './styles';
+import { trackHeaderLinkClick } from './trackHeaderLinkClick';
 
 // The docs sidebar tree isn't reachable via React Context from here (see
 // below), so we borrow it from the secondary-menu "teleport" that Docusaurus's
@@ -72,6 +73,22 @@ export default function MarketingHeaderHost(): JSX.Element {
       />
     );
   }, [shadowRoot, sidebar, activePath]);
+
+  useEffect(() => {
+    if (!shadowRoot) return;
+
+    const onClick: EventListener = (event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const anchor = target.closest('a');
+      if (anchor instanceof HTMLAnchorElement) {
+        trackHeaderLinkClick(anchor);
+      }
+    };
+
+    shadowRoot.addEventListener('click', onClick);
+    return () => shadowRoot.removeEventListener('click', onClick);
+  }, [shadowRoot]);
 
   return (
     <div

--- a/src/components/MarketingHeader/trackHeaderLinkClick.ts
+++ b/src/components/MarketingHeader/trackHeaderLinkClick.ts
@@ -1,0 +1,17 @@
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+  }
+}
+
+export function trackHeaderLinkClick(anchor: HTMLAnchorElement): void {
+  if (typeof window === 'undefined') return;
+
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push({
+    event: 'Header Link Click',
+    click_text: (anchor.textContent ?? '').trim(),
+    click_url: anchor.href,
+    click_classes: anchor.className,
+  });
+}


### PR DESCRIPTION
The marketing header renders inside Shadow DOM, so GTM's built-in link click triggers miss the actual anchors. This adds a delegated shadow-root listener that pushes "Header Link Click" events with link metadata.