### PR TITLE
Open Cookiebot settings from the footer via `Cookiebot.renew()`

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1002,6 +1002,11 @@ html[data-has-hydrated='true'] .max-serve-api-wrapper {
 // ============================================================
 // CookiebotDialog overrides
 // ============================================================
+
+#CookiebotWidget {
+  display: none !important;
+}
+
 #CybotCookiebotDialog {
   border: 1px solid var(--Elements-Twilight-50) !important;
   background-color: var(--Elements-Twilight-0-90) !important;

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -6,7 +6,7 @@ import styles from './styles.module.scss';
 
 declare global {
   interface Window {
-    Cookiebot?: { show: () => void };
+    Cookiebot?: { renew: () => void };
   }
 }
 
@@ -53,7 +53,7 @@ export default function Footer(): JSX.Element | null {
           <button
             type="button"
             className={`${styles.link} ${styles.privacyButton}`}
-            onClick={() => window.Cookiebot?.show()}
+            onClick={() => window.Cookiebot?.renew()}
           >
             Privacy settings
           </button>


### PR DESCRIPTION
Hide the floating Privacy Trigger so users change consent from the footer link instead of the corner widget.

This abides by GDPR rules, as described by Cookiebot here:
https://support.cookiebot.com/hc/en-us/articles/360003798814-Changing-or-withdrawing-consent

NOTE: the preview stage or local build will not show the Cookiebot dialogs because Cookiebot is configured to initialize only on the production website.